### PR TITLE
Refactor to classic-level 2.0 API

### DIFF
--- a/guest.js
+++ b/guest.js
@@ -376,7 +376,7 @@ class ManyLevelGuest extends AbstractLevel {
       const remote = this[kRemote]()
       pipeline(
         remote,
-        this.connect(),
+        this.createRpcStream(),
         remote
       ).catch(err => {
         // TODO: proper abort handling

--- a/guest.js
+++ b/guest.js
@@ -151,13 +151,15 @@ class ManyLevelGuest extends AbstractLevel {
     function oncallback (res) {
       const req = self[kRequests].remove(res.id)
       if (!req || !req.callback) return
-      req.callback(res.error ? new ModuleError('Could not get value', { code: res.error }) : null, normalizeValue(res.value))
+      if (res.error) req.callback(new ModuleError('Could not get value', { code: res.error }))
+      else req.callback(null, normalizeValue(res.value))
     }
 
     function ongetmanycallback (res) {
       const req = self[kRequests].remove(res.id)
       if (!req || !req.callback) return
-      req.callback(res.error ? new ModuleError('Could not get value', { code: res.error }) : null, normalizeValue(res.value))
+      if (res.error) req.callback(new ModuleError('Could not get values', { code: res.error }))
+      else req.callback(null, res.values.map(v => normalizeValue(v.value)))
     }
   }
 

--- a/guest.js
+++ b/guest.js
@@ -443,6 +443,8 @@ class ManyLevelGuestIterator extends AbstractIterator {
       return
     }
     // If nothing is pending, wait for the host to send more data
+    // TODO: except if this[kEnded] is true and nothing is pending, then
+    //   don't wait! Return undefined.
     if (!this[kPending].length) {
       const { promise, callback } = promiseFactory()
       this[kCallback] = callback
@@ -466,6 +468,8 @@ class ManyLevelGuestIterator extends AbstractIterator {
     }
 
     const consumed = ++req.consumed
+    // TODO: might need to add `.toString()` to the key and value to convert from Buffer
+    // Depends on whether abstract level does that itself or not.
     const key = req.options.keys ? next.data.shift() : undefined
     const val = req.options.values ? next.data.shift() : undefined
 

--- a/guest.js
+++ b/guest.js
@@ -373,13 +373,13 @@ class ManyLevelGuest extends AbstractLevel {
   }
 
   _iterator (options) {
-    return new Iterator(this, options)
+    return new ManyLevelGuestIterator(this, options)
   }
 }
 
 exports.ManyLevelGuest = ManyLevelGuest
 
-class Iterator extends AbstractIterator {
+class ManyLevelGuestIterator extends AbstractIterator {
   constructor (db, options) {
     // Need keys to know where to restart
     if (db[kRetry]) options.keys = true

--- a/guest.js
+++ b/guest.js
@@ -135,6 +135,7 @@ class ManyLevelGuest extends AbstractLevel {
       const req = self[kIterators].get(res.id)
       if (!req || req.iterator[kSeq] !== res.seq) return
       req.iterator[kPending].push(res)
+      // TODO: deprecate callbacks
       if (req.iterator[kCallback]) req.iterator._next(req.iterator[kCallback])
     }
 
@@ -143,9 +144,11 @@ class ManyLevelGuest extends AbstractLevel {
       if (!req || req.iterator[kSeq] !== res.seq) return
       // https://github.com/Level/abstract-level/issues/19
       req.iterator[kEnded] = true
+      // TODO: deprecate callbacks
       if (req.iterator[kCallback]) req.iterator._next(req.iterator[kCallback])
     }
 
+    // TODO: no more callbacks
     function oncallback (res) {
       const req = self[kRequests].remove(res.id)
       if (!req) return
@@ -153,6 +156,7 @@ class ManyLevelGuest extends AbstractLevel {
       else req.promise.then(null, normalizeValue(res.value))
     }
 
+    // TODO: no more callbacks
     function ongetmanycallback (res) {
       const req = self[kRequests].remove(res.id)
       if (!req) return
@@ -197,6 +201,7 @@ class ManyLevelGuest extends AbstractLevel {
 
     for (const req of this[kIterators].clear()) {
       // Cancel in-flight operation if any
+      // TODO: do we need a new mechanism to pass the error back up to the request initiator?
       const callback = req.iterator[kCallback]
       req.iterator[kCallback] = null
 
@@ -310,6 +315,7 @@ class ManyLevelGuest extends AbstractLevel {
     this[kAbortRequests]('Aborted on database close()', 'LEVEL_DATABASE_NOT_OPEN')
 
     if (this[kRpcStream]) {
+      // TODO: need to do something with finished. Can we use readable-stream.promises or whatever?? That would make life much easier...
       finished(this[kRpcStream], () => {
         this[kRpcStream] = null
         this._close()
@@ -326,6 +332,7 @@ class ManyLevelGuest extends AbstractLevel {
       // For tests only so does not need error handling
       this[kExplicitClose] = false
       const remote = this[kRemote]()
+      // TODO: Need to promisify pipeline
       pipeline(
         remote,
         this.connect(),

--- a/guest.js
+++ b/guest.js
@@ -213,26 +213,11 @@ class ManyLevelGuest extends AbstractLevel {
     }
   }
 
-  static _promiseFactory () {
-    let promiseResolve, promiseReject
-    const promise = new Promise((resolve, reject) => {
-      promiseResolve = resolve
-      promiseReject = reject
-    })
-    return {
-      promise,
-      callback: (err, value) => {
-        if (err) promiseReject(err)
-        else promiseResolve(value)
-      }
-    }
-  }
-
   async _get (key, opts) {
     // TODO: this and other methods assume db state matches our state
     if (this[kDb]) return this[kDb]._get(key, opts)
 
-    const { promise, callback } = ManyLevelGuest._promiseFactory()
+    const { promise, callback } = promiseFactory()
     const req = {
       tag: input.get,
       id: 0,
@@ -249,7 +234,7 @@ class ManyLevelGuest extends AbstractLevel {
   async _getMany (keys, opts) {
     if (this[kDb]) return this[kDb]._getMany(keys, opts)
 
-    const { promise, callback } = ManyLevelGuest._promiseFactory()
+    const { promise, callback } = promiseFactory()
     const req = {
       tag: input.getMany,
       id: 0,
@@ -266,7 +251,7 @@ class ManyLevelGuest extends AbstractLevel {
   async _put (key, value, opts) {
     if (this[kDb]) return this[kDb]._put(key, value, opts)
 
-    const { promise, callback } = ManyLevelGuest._promiseFactory()
+    const { promise, callback } = promiseFactory()
     const req = {
       tag: input.put,
       id: 0,
@@ -284,7 +269,7 @@ class ManyLevelGuest extends AbstractLevel {
   async _del (key, opts) {
     if (this[kDb]) return this[kDb]._del(key, opts)
 
-    const { promise, callback } = ManyLevelGuest._promiseFactory()
+    const { promise, callback } = promiseFactory()
     const req = {
       tag: input.del,
       id: 0,
@@ -301,7 +286,7 @@ class ManyLevelGuest extends AbstractLevel {
   async _batch (batch, opts) {
     if (this[kDb]) return this[kDb]._batch(batch, opts)
 
-    const { promise, callback } = ManyLevelGuest._promiseFactory()
+    const { promise, callback } = promiseFactory()
     const req = {
       tag: input.batch,
       id: 0,
@@ -318,7 +303,7 @@ class ManyLevelGuest extends AbstractLevel {
   async _clear (opts) {
     if (this[kDb]) return this[kDb]._clear(opts)
 
-    const { promise, callback } = ManyLevelGuest._promiseFactory()
+    const { promise, callback } = promiseFactory()
     const req = {
       tag: input.clear,
       id: 0,
@@ -507,6 +492,21 @@ class Iterator extends AbstractIterator {
     await this.db[kWrite]({ tag: input.iteratorClose, id: this[kRequest].id })
     this.db[kIterators].remove(this[kRequest].id)
     this.db[kFlushed]()
+  }
+}
+
+function promiseFactory () {
+  let promiseResolve, promiseReject
+  const promise = new Promise((resolve, reject) => {
+    promiseResolve = resolve
+    promiseReject = reject
+  })
+  return {
+    promise,
+    callback: (err, value) => {
+      if (err) promiseReject(err)
+      else promiseResolve(value)
+    }
   }
 }
 

--- a/guest.js
+++ b/guest.js
@@ -203,10 +203,9 @@ class ManyLevelGuest extends AbstractLevel {
       req.callback(new ModuleError(msg, { code }))
     }
 
-    // TODO: iterators
     for (const req of this[kIterators].clear()) {
       // Cancel in-flight operation if any
-      // TODO: do we need a new mechanism to pass the error back up to the request initiator?
+      // TODO: does this need to be refactored to use AbortError to pass back up to the request initiator?
       const callback = req.iterator[kCallback]
       req.iterator[kCallback] = null
 
@@ -379,7 +378,6 @@ class ManyLevelGuest extends AbstractLevel {
         this.createRpcStream(),
         remote
       ).catch(err => {
-        // TODO: proper abort handling
         if (err.code === 'ABORT_ERR') {
           return this.close()
         }
@@ -473,7 +471,7 @@ class ManyLevelGuestIterator extends AbstractIterator {
       return
     }
     // If nothing is pending, wait for the host to send more data
-    // TODO: except if this[kEnded] is true and nothing is pending, then
+    // except if this[kEnded] is true and nothing is pending, then
     //   don't wait! Return undefined.
     if (this[kEnded] && !this[kPending].length) {
       return undefined

--- a/guest.js
+++ b/guest.js
@@ -220,9 +220,11 @@ class ManyLevelGuest extends AbstractLevel {
       promiseReject = reject
     })
     return {
-      resolve: promiseResolve,
-      reject: promiseReject,
-      promise
+      promise,
+      callback: (err, value) => {
+        if (err) promiseReject(err)
+        else promiseResolve(value)
+      }
     }
   }
 
@@ -230,12 +232,12 @@ class ManyLevelGuest extends AbstractLevel {
     // TODO: this and other methods assume db state matches our state
     if (this[kDb]) return this[kDb]._get(key, opts)
 
-    const { promise, resolve, reject } = ManyLevelGuest._promiseFactory()
+    const { promise, callback } = ManyLevelGuest._promiseFactory()
     const req = {
       tag: input.get,
       id: 0,
       key: key,
-      callback: (err, value) => err ? reject(err) : resolve(value)
+      callback
     }
 
     req.id = this[kRequests].add(req)
@@ -247,12 +249,12 @@ class ManyLevelGuest extends AbstractLevel {
   async _getMany (keys, opts) {
     if (this[kDb]) return this[kDb]._getMany(keys, opts)
 
-    const { promise, resolve, reject } = ManyLevelGuest._promiseFactory()
+    const { promise, callback } = ManyLevelGuest._promiseFactory()
     const req = {
       tag: input.getMany,
       id: 0,
       keys: keys,
-      callback: (err, value) => err ? reject(err) : resolve(value)
+      callback
     }
 
     req.id = this[kRequests].add(req)
@@ -264,13 +266,13 @@ class ManyLevelGuest extends AbstractLevel {
   async _put (key, value, opts) {
     if (this[kDb]) return this[kDb]._put(key, value, opts)
 
-    const { promise, resolve, reject } = ManyLevelGuest._promiseFactory()
+    const { promise, callback } = ManyLevelGuest._promiseFactory()
     const req = {
       tag: input.put,
       id: 0,
       key: key,
       value: value,
-      callback: (err, value) => err ? reject(err) : resolve(value)
+      callback
     }
 
     req.id = this[kRequests].add(req)
@@ -282,12 +284,12 @@ class ManyLevelGuest extends AbstractLevel {
   async _del (key, opts) {
     if (this[kDb]) return this[kDb]._del(key, opts)
 
-    const { promise, resolve, reject } = ManyLevelGuest._promiseFactory()
+    const { promise, callback } = ManyLevelGuest._promiseFactory()
     const req = {
       tag: input.del,
       id: 0,
       key: key,
-      callback: (err, value) => err ? reject(err) : resolve(value)
+      callback
     }
 
     req.id = this[kRequests].add(req)
@@ -299,12 +301,12 @@ class ManyLevelGuest extends AbstractLevel {
   async _batch (batch, opts) {
     if (this[kDb]) return this[kDb]._batch(batch, opts)
 
-    const { promise, resolve, reject } = ManyLevelGuest._promiseFactory()
+    const { promise, callback } = ManyLevelGuest._promiseFactory()
     const req = {
       tag: input.batch,
       id: 0,
       ops: batch,
-      callback: (err, value) => err ? reject(err) : resolve(value)
+      callback
     }
 
     req.id = this[kRequests].add(req)
@@ -316,12 +318,12 @@ class ManyLevelGuest extends AbstractLevel {
   async _clear (opts) {
     if (this[kDb]) return this[kDb]._clear(opts)
 
-    const { promise, resolve, reject } = ManyLevelGuest._promiseFactory()
+    const { promise, callback } = ManyLevelGuest._promiseFactory()
     const req = {
       tag: input.clear,
       id: 0,
       options: opts,
-      callback: (err, value) => err ? reject(err) : resolve(value)
+      callback
     }
 
     req.id = this[kRequests].add(req)

--- a/host.js
+++ b/host.js
@@ -65,7 +65,7 @@ function createRpcStream (db, options, streamOptions) {
   const predel = options.predel
   const prebatch = options.prebatch
 
-  db.open({ passive: true }, ready)
+  db.open({ passive: true }).then(() => ready()).catch(ready)
 
   // TODO: send events to guest. Challenges:
   // - Need to know encodings or emit encoded data; current abstract-level events don't suffice

--- a/host.js
+++ b/host.js
@@ -85,12 +85,7 @@ function createRpcStream (db, options, streamOptions) {
     const iterators = new Map()
 
     const cleanup = async () => {
-      await finished(stream).catch(err => {
-        // Abort error is expected on close, which is what triggers finished
-        if (err.code !== 'ABORT_ERR') {
-          throw err
-        }
-      })
+      await finished(stream).catch(() => null)
       for (const iterator of iterators.values()) {
         iterator.close()
       }

--- a/host.js
+++ b/host.js
@@ -185,7 +185,7 @@ function createRpcStream (db, options, streamOptions) {
     function oniterator ({ id, seq, options, consumed, bookmark, seek }) {
       if (iterators.has(id)) return
 
-      const it = new Iterator(db, id, seq, options, consumed, encode)
+      const it = new ManyLevelHostIterator(db, id, seq, options, consumed, encode)
       iterators.set(id, it)
 
       if (seek) {
@@ -229,7 +229,7 @@ function createRpcStream (db, options, streamOptions) {
   }
 }
 
-class Iterator {
+class ManyLevelHostIterator {
   constructor (db, id, seq, options, consumed, encode) {
     options = cleanRangeOptions(options)
 

--- a/host.js
+++ b/host.js
@@ -218,10 +218,13 @@ function createRpcStream (db, options, streamOptions) {
       if (it !== undefined) it.close()
     }
 
-    function onclear (req) {
-      db.clear(cleanRangeOptions(req.options), function (err) {
-        callback(req.id, err)
-      })
+    async function onclear (req) {
+      try {
+        await db.clear(cleanRangeOptions(req.options))
+        return callback(req.id, null)
+      } catch (err) {
+        return callback(req.id, err)
+      }
     }
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,6 @@ import {
   AbstractLevel,
   AbstractDatabaseOptions,
   AbstractOpenOptions,
-  NodeCallback
 } from 'abstract-level'
 
 // Requires `npm install @types/readable-stream`.
@@ -25,8 +24,6 @@ export class ManyLevelGuest<KDefault = string, VDefault = string>
 
   open (): Promise<void>
   open (options: GuestOpenOptions): Promise<void>
-  open (callback: NodeCallback<void>): void
-  open (options: GuestOpenOptions, callback: NodeCallback<void>): void
 
   /**
    * Create a duplex guest stream to be piped into a host stream. Until that's done,
@@ -158,17 +155,17 @@ declare interface HostOptions {
   /**
    * A function to be called before `db.put()` operations.
    */
-  preput?: (key: Buffer, value: Buffer, callback: NodeCallback<void>) => void
+  preput?: (key: Buffer, value: Buffer) => Promise<void>
 
   /**
    * A function to be called before `db.del()` operations.
    */
-  predel?: (key: Buffer, callback: NodeCallback<void>) => void
+  predel?: (key: Buffer) => Promise<void>
 
   /**
    * A function to be called before `db.batch()` operations.
    */
-  prebatch?: (operations: HostBatchOperation[], callback: NodeCallback<void>) => void
+  prebatch?: (operations: HostBatchOperation[]) => Promise<void>
 }
 
 declare type HostBatchOperation = HostBatchPutOperation | HostBatchDelOperation

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 import {
   AbstractLevel,
   AbstractDatabaseOptions,
-  AbstractOpenOptions,
+  AbstractOpenOptions
 } from 'abstract-level'
 
 // Requires `npm install @types/readable-stream`.

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "faucet": "^0.0.3",
     "hallmark": "^4.0.0",
     "level-read-stream": "^1.1.0",
-    "memory-level": "^1.0.0",
+    "memory-level": "^2.0.0",
     "nyc": "^15.1.0",
     "protocol-buffers": "^5.0.0",
     "standard": "^16.0.3",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "homepage": "https://github.com/Level/many-level",
   "engines": {
-    "node": ">=12"
+    "node": ">=16"
   },
   "standard": {
     "ignore": [

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "types": "./index.d.ts",
   "scripts": {
     "test": "standard && ts-standard *.ts && hallmark && (nyc -s tape test/*.js | faucet) && nyc report",
+    "test:stacktrace": "nyc -s tape test/*.js && nyc report",
     "coverage": "nyc report -r lcovonly",
     "hallmark": "hallmark --fix",
     "protobuf": "protocol-buffers schema.proto -o messages.js",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "@vweevers/length-prefixed-stream": "^1.0.0",
-    "abstract-level": "^1.0.3",
+    "abstract-level": "^2.0.2",
     "module-error": "^1.0.2",
     "protocol-buffers-encodings": "^1.1.0",
     "readable-stream": "^4.0.0"


### PR DESCRIPTION
Switch to using Promises instead of callbacks. This works well enough for Foundry's use case. There are a few features which Foundry does not use which still fail the test suite.